### PR TITLE
Fractal Damage and Context Menu, And Commander Cluster Weapon Scaling

### DIFF
--- a/LuaRules/Gadgets/weapon_cluster_ammunition_spawner.lua
+++ b/LuaRules/Gadgets/weapon_cluster_ammunition_spawner.lua
@@ -446,9 +446,12 @@ local function SpawnSubProjectiles(id, wd)
 				local dy = projectileattributes["speed"][2] - 1 --hackity hax
 				local dz = projectileattributes["speed"][3]
 				--do not question the arctangent
-				local dirX = math.atan2(dx, sqrt(dy*dy+dz*dz))
-				local dirY = math.atan2(dy, sqrt(dx*dx+dz*dz))
-				local dirZ = math.atan2(dz, sqrt(dx*dx+dy*dy))
+				local dx2 = dx*dx	
+				local dy2 = dy*dy
+				local dz2 = dz*dz
+				local dirX = atan2(dx, sqrt(dy2 + dz2))
+				local dirY = atan2(dy, sqrt(dx2 + dz2))
+				local dirZ = atan2(dz, sqrt(dx2 + dy2))
 				spSpawnSFX(projectileattributes["owner"], projectileConfig[j].spawnsfx, projectileattributes["pos"][1], projectileattributes["pos"][2], projectileattributes["pos"][3], dirX, dirY, dirZ, true)
 			else
 				p = spSpawnProjectile(me, projectileattributes)

--- a/LuaRules/Gadgets/weapon_cluster_ammunition_spawner.lua
+++ b/LuaRules/Gadgets/weapon_cluster_ammunition_spawner.lua
@@ -79,6 +79,7 @@ local random = math.random
 local sqrt = math.sqrt
 local byte = string.byte
 local abs = math.abs
+local atan2 = math.atan2
 local pi = math.pi
 local halfpi = pi/2
 local abs = math.abs -- CAS GOES TO THE GYM AND HAS DOUBLE ABS

--- a/LuaUI/Widgets/gui_contextmenu.lua
+++ b/LuaUI/Widgets/gui_contextmenu.lua
@@ -942,7 +942,16 @@ local function weapons2Table(cells, ws, unitID)
 			cells[#cells+1] = ' - Inaccuracy vs moving targets'
 			cells[#cells+1] = '' -- actual value doesn't say much as it's a multiplier for the target speed
 		end
-
+		
+		if cp.stats_custom_tooltip_1 then
+		local q = 1
+			while cp["stats_custom_tooltip_" .. q] do
+			cells[#cells+1] = cp["stats_custom_tooltip_" .. q] or ""
+			cells[#cells+1] = cp["stats_custom_tooltip_entry_" .. q] or ""
+			q = q + 1
+			end
+		end
+		
 		if wd.targetable and ((wd.targetable == 1) or (wd.targetable == true)) then
 			cells[#cells+1] = ' - Can be shot down by antinukes'
 			cells[#cells+1] = ''

--- a/gamedata/modularcomms/weapons/clusterbomb.lua
+++ b/gamedata/modularcomms/weapons/clusterbomb.lua
@@ -21,6 +21,7 @@ local weaponDef = {
 		spawndist = 180, -- at what distance should we spawn the projectile(s)? REQUIRED.
 		timeoutspawn = 1, -- Can this missile spawn its subprojectiles when it times out? OPTIONAL. Default: 1.
 		vradius1 = "-2,-1,-2,2,0,2", -- velocity that is randomly added. covers range of +-vradius. OPTIONAL. Default: 4.2
+		dyndamage = "Never gonna give you up...",
 		light_camera_height = 2500,
 		light_color = [[0.22 0.19 0.05]],
 		light_radius = 380,

--- a/gamedata/modularcomms/weapons/commweapon_canistercannon.lua
+++ b/gamedata/modularcomms/weapons/commweapon_canistercannon.lua
@@ -26,6 +26,7 @@ local weaponDef = {
 		groundimpact = 1, -- check the distance between ground and projectile? OPTIONAL.
 		proxy = 1, -- check for nearby units?
 		proxydist = 100, -- how far to check for units? Default: spawndist
+		dyndamage = "Never gonna let you down...",
 		reaim_time = 60, -- Fast update not required (maybe dangerous)
 		light_camera_height = 1500,
 		light_color = [[0.8 0.76 0.38]],

--- a/units/vehsupport.lua
+++ b/units/vehsupport.lua
@@ -103,10 +103,14 @@ return {
 					vradius1 = "0,0,0,0,0,0", -- velocity that is randomly added. covers range of +-vradius. OPTIONAL. Default: 4.2
 					groundimpact = 0,
 					spawnsfx1 = 2049,
+					
+					custom_tooltip_1 = " - Damage decreases vs smaller targets",
+					shield_mult = 0.25,
 				},
 
 				damage                  = {
-					default = 118.02,
+					default = 84*8,
+					shield = 84*8*0.25
 				},
 
 				explosionGenerator      = [[custom:FLASH2]],

--- a/units/vehsupport.lua
+++ b/units/vehsupport.lua
@@ -104,7 +104,7 @@ return {
 					groundimpact = 0,
 					spawnsfx1 = 2049,
 					
-					custom_tooltip_1 = " - Damage decreases vs smaller targets",
+					stats_custom_tooltip_1 = " - Damage decreases vs smaller targets",
 					shield_mult = 0.25,
 				},
 

--- a/units/vehsupport.lua
+++ b/units/vehsupport.lua
@@ -105,12 +105,11 @@ return {
 					spawnsfx1 = 2049,
 					
 					stats_custom_tooltip_1 = " - Damage decreases vs smaller targets",
-					shield_mult = 0.25,
+					damage_vs_shield = 84*8*0.25,
 				},
 
 				damage                  = {
 					default = 84*8,
-					shield = 84*8*0.25
 				},
 
 				explosionGenerator      = [[custom:FLASH2]],


### PR DESCRIPTION
**Fixes**
 - Fractal Damage values are now consistent with other cluster weapons
 
**Enhancements**
 - Fractal context menu now reflect it's damage decrease and shield damage
 - Fractal now deals 25% damage against shields
 - Commander Cluster Weapons now spawn more subprojectiles the more damage boosters the parent comm has. Decimal numbers represent a chance to spawn an extra one (e.g. a cluster bomb has 6 subprojectiles normally, with the +10% from a damage booster it becomes 6.6 subprojectiles. which means a 60% chance to spawn 7 and a 40% chance to spawn 6)