### PR TITLE
"Balancing" and CEG + sound control for Vulcan

### DIFF
--- a/scripts/striderdante.lua
+++ b/scripts/striderdante.lua
@@ -441,11 +441,19 @@ function script.Shot(num)
 end
 
 function script.BlockShot(num, targetID)
-	if num ~= 1 then
-		return false
+	if num == 2 then
+		if not targetID or spValidUnitID(targetID) then --try and fix a bug I caught in testing
+			return false
+		else
+			return true
+		end
+	else
+		if num ~= 1 then
+			return false
+		end
+		local reloadState = Spring.GetUnitWeaponState(unitID, 3, 'reloadState')
+		return not (reloadState and (reloadState < 0 or reloadState < Spring.GetGameFrame()))
 	end
-	local reloadState = Spring.GetUnitWeaponState(unitID, 3, 'reloadState')
-	return not (reloadState and (reloadState < 0 or reloadState < Spring.GetGameFrame()))
 end
 
 function script.FireWeapon(num)


### PR DESCRIPTION
Vulcan:
 - gain range on all of it's weapons (might've made vulcan op, need to see it in real games)
 - It's napalm fragments now spawn with the correct amount of speed and no longer spawn CEGs during the transition from dummy to non-dummy
 - It's heatrays and flamethrowers have "quieter" sounds (they are still as loud and Base dante, before it was very loud as they were played around 80 times per sec for the flamethrower and over 300 per sec for the heatray)
 - Context menu text no longer collides