### PR TITLE
Explode no longer causes spring to explode

### DIFF
--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -64,6 +64,20 @@ local function lowerkeys(t)
 	return tn
 end
 
+local function Explode(div, str)
+	if div == '' then
+		return false
+	end
+	local pos, arr = 0, {}
+	-- for each divider found
+	for st, sp in function() return string.find(str, div, pos, true) end do
+		table.insert(arr, string.sub(str, pos, st - 1)) -- Attach chars left of current divider
+		pos = sp + 1 -- Jump past current divider
+	end
+	table.insert(arr,string.sub(str,pos)) -- Attach chars right of last divider
+	return arr
+end
+
 local function GetDimensions(scale)
 	if not scale then
 		return false
@@ -79,20 +93,6 @@ local function GetDimensions(scale)
 		largest = math.max(largest, (dimensions and dimensions[i] and tonumber(dimensions[i])) or 0)
 	end
 	return dimensions, largest
-end
-
-local function Explode(div, str)
-	if div == '' then
-		return false
-	end
-	local pos, arr = 0, {}
-	-- for each divider found
-	for st, sp in function() return string.find(str, div, pos, true) end do
-		table.insert(arr, string.sub(str, pos, st - 1)) -- Attach chars left of current divider
-		pos = sp + 1 -- Jump past current divider
-	end
-	table.insert(arr,string.sub(str,pos)) -- Attach chars right of last divider
-	return arr
 end
 
 --deep not safe with circular tables! defaults To false


### PR DESCRIPTION
> [f=-000001] Warning: [Game::Load][1] forced quit with exception "Defs-Parser: [pcall] error 2 ("[string "gamedata/defs.lua"]:38: [string "gamedata/defs.lua"]:26: error = 2, gamedata/unitDefs.lua, error = 2, gamedata/unitdefs_post.lua, [string "gamedata/unitdefs_post.lua"]:71: attempt to call global 'Explode' (a nil value)

> **global 'Explode'**

Was that intentional? whether it was or it wasn't that was comedy gold.