### PR TITLE
Scythe cloakstrike Defs

### DIFF
--- a/LuaRules/Configs/cloakstrike_def.lua
+++ b/LuaRules/Configs/cloakstrike_def.lua
@@ -3,11 +3,10 @@
 local StrikeWepDefs = {}
 
 local StrikeWepDefNames = {
-
+		cloakheavyraid = {
+		persistance = 30, cloakRecharge = 2, maxRecharge = 60, attackDecharge = -1, WeaponStats = {[1] = {cloakedWeaponStates = {}, decloakedWeaponStates = {}, cloakedWeaponDamages = {[0] = 855, [1] = 855, [2] = 855, [3] = , [4] = 855, [5] = 855}, decloakedWeaponDamages = {[0] = 285, [1] = 285, [2] = 285, [3] = 285, [4] = 285, [5] = 285},}}, cloakedRulesParam = {selfMoveSpeedChange = 1.5}, decloakedRulesParam = {selfMoveSpeedChange = 1}, updateAttributes = true
+	}
 }
---[[	cloakheavyraid = {
-		persistance = 30, cloakRecharge = 2, maxRecharge = 60, attackDecharge = -1, WeaponStats = {[1] = {cloakedWeaponStates = {}, decloakedWeaponStates = {}, cloakedWeaponDamages = {[0] = 10000, [1] = 10000, [2] = 10000, [3] = 10000, [4] = 10000, [5] = 10000}, decloakedWeaponDamages = {[0] = 10000, [1] = 10000, [2] = 10000, [3] = 10000, [4] = 10000, [5] = 10000},}},
-	},]]--
 local defaultStates = {
 		persistance = 30, cloakRecharge = 2, maxRecharge = 60, attackDecharge = -1, WeaponStats = {},
 }


### PR DESCRIPTION
Scythe:
 - Gains 3x damage when attacking while cloaked or within less that 1 second of decloaking
 - Gains 50% speed while cloaked