### PR TITLE
Scythe Base damage Nerf

### DIFF
--- a/units/cloakheavyraid.lua
+++ b/units/cloakheavyraid.lua
@@ -94,7 +94,7 @@ return {
 				},
       
 				damage                  = {
-					default = 380.1,
+					default = 285.1,
 				},
 
 				explosionGenerator      = [[custom:BEAMWEAPON_HIT_ORANGE]],


### PR DESCRIPTION
Scythe lose 25% of base damage to make up for cloakstrike