### PR TITLE
Scylla => Charybdis (unitdefs)

### DIFF
--- a/units/subtacmissile.lua
+++ b/units/subtacmissile.lua
@@ -2,11 +2,11 @@ return {
 	subtacmissile = {
 		unitname               = [[subtacmissile]],
 		name                   = [[Scylla]],
-		description            = [[Tactical Nuke Missile Sub, Drains 20 m/s, 30 second stockpile]],
+		description            = [[Tactical Nuke Missile Sub, Drains 24 m/s, 50 second stockpile]],
 		acceleration           = 0.223,
 		activateWhenBuilt      = true,
 		brakeRate              = 2.33,
-		buildCostMetal         = 3000,
+		buildCostMetal         = 3600,
 		builder                = false,
 		buildPic               = [[subtacmissile.png]],
 		canGuard               = true,
@@ -20,8 +20,8 @@ return {
 		customParams           = {
 			bait_level_default = 0,
 			modelradius    = [[15]],
-			stockpiletime  = [[30]],
-			stockpilecost  = [[600]],
+			stockpiletime  = [[45]],
+			stockpilecost  = [[1200]],
 			priority_misc  = 1, -- Medium
 			no_auto_keep_target = 1,
 		},
@@ -32,7 +32,7 @@ return {
 		iconType               = [[subtacmissile]],
 		idleAutoHeal           = 5,
 		idleTime               = 1800,
-		maxDamage              = 3000,
+		maxDamage              = 3750,
 		maxVelocity            = 2.79,
 		minWaterDepth          = 15,
 		movementClass          = [[UBOAT3]],
@@ -57,7 +57,10 @@ return {
 		},
 		weaponDefs             = {
 			TACNUKE        = {
-				name                    = [[Submarine Launched Tactical Nuke Strike]],
+				name                    = [[Tactical MIRV SLBM]],
+					--Tactical
+					--Multiple Independently-retargetable Reentry Vehicle
+					--Submarine Launched Ballistic Missile
 				areaOfEffect            = 256,
 				collideFriendly         = false,
 				commandfire             = true,
@@ -65,11 +68,27 @@ return {
 				craterMult              = 3.5,
 
 				customParams = {
-					burst = Shared.BURST_RELIABLE,
+					numprojectiles1 = 6, -- how many of the weapondef we spawn. OPTIONAL. Default: 1.
+					projectile1 = "subtacmissile_warhead",
+					spreadradius1 = 4, -- used in clusters. OPTIONAL. Default: 100.
+					clustervec1 = "randomxz", -- accepted values: randomx, randomy, randomz, randomxy, randomxz, randomyz, random. OPTIONAL. default: random.
+					spawndist = 900, -- at what distance should we spawn the projectile(s)? REQUIRED.
+					timeoutspawn = 0, -- Can this missile spawn its subprojectiles when it times out? OPTIONAL. Default: 1.
+					vradius1 = 0, -- velocity that is randomly added. covers range of +-vradius. OPTIONAL. Default: 4.2
+					usertargetable = 1,
+					reaim_time = 60, -- Fast update not required (maybe dangerous)
+					
+					
+					stats_custom_tooltip_1 = " - Carries MIRV Warheads",
+					stats_custom_tooltip_entry_1 = "",
+					stats_custom_tooltip_2 = "    - Warhead Count:",
+					stats_custom_tooltip_entry_2 = "6",
+					stats_custom_tooltip_3 = "    - Warhead Range:",
+					stats_custom_tooltip_entry_3 = "500 elmos",
 				},
 
 				damage                  = {
-					default = 3502.4,
+					default = 1800*6,
 				},
 
 				edgeEffectiveness       = 0.4,
@@ -94,6 +113,44 @@ return {
 				weaponAcceleration      = 180,
 				weaponTimer             = 4,
 				weaponType              = [[StarburstLauncher]],
+				weaponVelocity          = 1200,
+			},
+			WARHEAD        = {
+				name                    = [[Ima probably take a break, key word being probably.]],
+				areaOfEffect            = 196,
+				collideFriendly         = false,
+				commandfire             = true,
+				craterBoost             = 4,
+				craterMult              = 3.5,
+
+				customParams = {
+				},
+
+				damage                  = {
+					default = 1801.2,
+				},
+
+				edgeEffectiveness       = 0.7,
+				explosionGenerator      = [[custom:NUKE_150]],
+				fireStarter             = 0,
+				flightTime              = 10,
+				impulseBoost            = 0,
+				impulseFactor           = 0.4,
+				interceptedByShieldType = 1,
+				model                   = [[zeppelin_bomb.dae]],
+				noSelfDamage            = true,
+				range                   = 3000,
+				reloadtime              = 1,
+				smokeTrail              = true,
+				soundHit                = [[explosion/mini_nuke]],
+				soundStart              = [[weapon/missile/tacnuke_launch]],
+				stockpile               = true,
+				stockpileTime           = 10^5,
+				tolerance               = 4000,
+				turnrate                = 40000,
+				waterWeapon             = true,
+				weaponAcceleration      = 180,
+				weaponType              = [[MissileLauncher]],
 				weaponVelocity          = 1200,
 			},
 		},


### PR DESCRIPTION
Scylla => Charybdis
 - Stockpile cost and time increased to 1200m over 50s (24m/s)
 - Missiles now are MIRVS, with 6 warheads.
 - each warhead deals 1800 damage with 196 aoe
 - warhead dispersal range is 500 elmos